### PR TITLE
Turn the boolean operations into compas plugins

### DIFF
--- a/src/compas_cgal/__init__.py
+++ b/src/compas_cgal/__init__.py
@@ -64,4 +64,5 @@ DOCS = os.path.abspath(os.path.join(HOME, "docs"))
 TEMP = os.path.abspath(os.path.join(HOME, "temp"))
 
 
+__all_plugins__ = ['compas_cgal.booleans']
 __all__ = ["HOME", "DATA", "DOCS", "TEMP"]

--- a/src/compas_cgal/booleans.py
+++ b/src/compas_cgal/booleans.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from __future__ import division
 
 import numpy as np
+
+from compas.plugins import plugin
 from compas_cgal._cgal import booleans
 
 
@@ -54,17 +56,20 @@ def _boolean(A, B, operation):
     else:
         raise NotImplementedError
 
-    return result
+    return result.vertices, result.faces
 
 
+@plugin(category='booleans', pluggable_name='boolean_union_mesh_mesh')
 def boolean_union(A, B):
     return _boolean(A, B, 'union')
 
 
+@plugin(category='booleans', pluggable_name='boolean_difference_mesh_mesh')
 def boolean_difference(A, B):
     return _boolean(A, B, 'difference')
 
 
+@plugin(category='booleans', pluggable_name='boolean_intersection_mesh_mesh')
 def boolean_intersection(A, B):
     return _boolean(A, B, 'intersection')
 


### PR DESCRIPTION
As described in https://github.com/compas-dev/compas/pull/598, this PR adds COMPAS `@plugin` decorators to the boolean operations.